### PR TITLE
fix bug

### DIFF
--- a/navicat-keygen/Helper.hpp
+++ b/navicat-keygen/Helper.hpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
+#include <cassert>
 
 namespace Helper {
     template<int min_num, int max_num>


### PR DESCRIPTION
When I make it in mac os 10.13.6, it will throw an error.

```bash
g++ -std=c++11 -O2 -I/usr/local/opt/openssl/include -L/usr/local/opt/openssl/lib -lcrypto ./navicat-patcher/Helper.cpp ./navicat-patcher/main.cpp ./navicat-patcher/Solution0.cpp ./navicat-patcher/Solution1.cpp -o ./bin/navicat-patcher
g++ -std=c++11 -O2 -I/usr/local/opt/openssl/include -L/usr/local/opt/openssl/lib -lcrypto ./navicat-keygen/Helper.cpp ./navicat-keygen/main.cpp -o ./bin/navicat-keygen
./navicat-keygen/Helper.cpp:47:13: error: use of undeclared identifier 'assert'
            assert(bits_collected < 6);
            ^
./navicat-keygen/Helper.cpp:51:9: error: use of undeclared identifier 'assert'
        assert(outpos >= (retval.size() - 2));
        ^
./navicat-keygen/Helper.cpp:52:9: error: use of undeclared identifier 'assert'
        assert(outpos <= retval.size());
```